### PR TITLE
isochron: Make signal_received static.

### DIFF
--- a/isochron/rcv.c
+++ b/isochron/rcv.c
@@ -45,7 +45,7 @@ struct prog_data {
 	long data_port;
 };
 
-int signal_received;
+static int signal_received;
 
 static int app_loop(void *app_data, char *rcvbuf, size_t len,
 		    const struct isochron_timestamp *tstamp)

--- a/isochron/send.c
+++ b/isochron/send.c
@@ -90,7 +90,7 @@ struct prog_data {
 	long data_port;
 };
 
-int signal_received;
+static int signal_received;
 
 static void trace(struct prog_data *prog, const char *fmt, ...)
 {


### PR DESCRIPTION
The variable signal_received is globally defined in rcv.c and send.c and
both objects are linked into the isochron binary. The linking fails
because the variable is declared twice and collides with the other one.

The variable is only used locally (within the compile unit) for the
purporse of signaling ctrl-c from the signal handler.

Make the variable static so it isn't exported outside of the compile
unit.

Signed-off-by: Sebastian Andrzej Siewior <bigeasy@linutronix.de>